### PR TITLE
Add Travis CI config and misc cleanups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: cpp
+git:
+  depth: 1
+os:
+  - linux
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - cmake
+      - g++-6
+before_script:
+  - export CXX=g++-6
+script:
+  - mkdir build && cd build
+  - cmake ..
+  - make VERBOSE=1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.2)
 
 project(tVM
-	LANGUAGES C CXX
+	LANGUAGES CXX
 	VERSION 0.0.1
 )
 

--- a/tvm/include/tvm/Compiler.hpp
+++ b/tvm/include/tvm/Compiler.hpp
@@ -5,6 +5,8 @@
 
 #include <sys/mman.h>
 #include <vector>
+#include <memory>
+#include <cstring>
 
 namespace tvm {
 
@@ -40,7 +42,7 @@ struct CodeCache {
    */
 
   void writeToCodeCache(const unsigned char * machineCode){
-    memcpy(start_, machineCode, size_);
+    std::memcpy(start_, machineCode, size_);
   }
 
   /**

--- a/tvm/src/Compiler.cpp
+++ b/tvm/src/Compiler.cpp
@@ -1,8 +1,5 @@
 #include "tvm/Compiler.hpp"
 
-#include <cassert>
-#include <cstring>
-
 namespace tvm {
 
 Compiler::Compiler(const std::vector<Instruction> &instructions)

--- a/tvm/src/ExecutionContext.cpp
+++ b/tvm/src/ExecutionContext.cpp
@@ -1,8 +1,6 @@
 #include "tvm/ExecutionContext.hpp"
 #include "tvm/VirtualMachine.hpp"
 
-#include <cassert>
-
 namespace tvm {
 
 ExecutionContext::ExecutionContext(VirtualMachine &virtualMachine,


### PR DESCRIPTION
This PR adds one Travis CI config that will build tVM on pushes to the repo and pull requests, fixes some minor bugs, and removes some unnecessary headers.